### PR TITLE
Simplifying the manifest file slicing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.class
+.out
+.idea
+*.iml
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
@@ -10,3 +13,5 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
 edx-analytics-hadoop-util
 =========================
 
-Building
---------
+Building Without Ant
+--------------------
 
 ```bash
-javac -cp $(hadoop classpath) org/edx/hadoop/input/ManifestTextInputFormat.java
-jar cf edx-analytics-hadoop-util.jar org/edx/hadoop/input/ManifestTextInputFormat.class
+javac -cp $(hadoop classpath) src/org/edx/hadoop/input/ManifestTextInputFormat.java
+jar cf edx-analytics-hadoop-util.jar src/org/edx/hadoop/input/ManifestTextInputFormat.class
 ```
+
+
+Building With Ant
+-----------------
+
+To use the ANT build file you must compile using the correct version of Java, and include the Hadoop jars that are
+specific to your environment stored in a `lib` directory.  For Hadoop 2.7.2 this means compiling using Java 1.7 and the
+following jars:
+
+- org.apache.hadoop:hadoop-common:2.7.2
+- org.apache.hadoop:hadoop-mapreduce-client-core:2.7.2
+
+Please note libraries are dependent upon the specific Hadoop version you are using.  Different versions of Hadoop may
+require vastly different libraries or versions of Java.  You will need to consult your Hadoop implementation to
+determine which libraries are appropriate for you situation.

--- a/edx-analytics-hadoop-util.xml
+++ b/edx-analytics-hadoop-util.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This is an ANT build file used to compile and generate the jar -->
+<project>
+    <path id="master-classpath">
+        <fileset dir="lib">
+            <include name="*.jar"/>
+        </fileset>
+    </path>
+    <target name="clean">
+        <delete dir="build"/>
+    </target>
+    <target name="compile">
+        <antcall target="clean" />
+        <mkdir dir="out/classes"/>
+        <javac srcdir="src" destdir="out/classes" classpathref="master-classpath" />
+    </target>
+    <target name="jar">
+        <antcall target="compile" />
+        <mkdir dir="out/jar"/>
+        <jar destfile="out/jar/edx-analytics-hadoop-util.jar" basedir="out/classes">
+            <manifest>
+            </manifest>
+        </jar>
+    </target>
+</project>

--- a/src/org/edx/hadoop/input/ManifestTextInputFormat.java
+++ b/src/org/edx/hadoop/input/ManifestTextInputFormat.java
@@ -1,10 +1,6 @@
 package org.edx.hadoop.input;
 
-import java.io.BufferedReader;
-import java.io.DataInputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.IOException;
+import java.io.*;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -13,20 +9,36 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.KeyValueTextInputFormat;
-import org.apache.commons.logging.LogFactory;
 
 
 public class ManifestTextInputFormat extends KeyValueTextInputFormat {
+    public static int RETRY_LIMIT = 10;
+    public static long REPORTING_INTERVAL = 1000l * 60 * 5;
 
     protected FileStatus[] listStatus(JobConf job) throws IOException {
         FileStatus[] manifests = super.listStatus(job);
         List<FileStatus> paths = new ArrayList<FileStatus>();
-        for(int i = 0; i < manifests.length; i++) {
-            List<Path> globPaths = this.readManifest(manifests[i].getPath(), job);
-            for (Path globPath : globPaths) {
+        long lastReportTime = System.currentTimeMillis();
+
+        for (FileStatus manifest : manifests) {
+            List<Path> globPaths = this.readManifest(manifest.getPath(), job);
+
+            for(int i = 0; i < globPaths.size(); i++) {
+                Path globPath = globPaths.get(i);
+
                 paths.addAll(this.expandPath(globPath, job));
+
+                if ((System.currentTimeMillis() - lastReportTime) >= REPORTING_INTERVAL) {
+                    lastReportTime = System.currentTimeMillis();
+
+                    if (globPath != null)
+                        LOG.info("Fetched " + i + " of " + globPaths.size() + " paths, most recently: " + globPath.toUri());
+                    else
+                        LOG.info("Fetched " + i + " of " + globPaths.size() + " paths.");
+                }
             }
         }
+
         return paths.toArray(new FileStatus[1]);
     }
 
@@ -50,7 +62,28 @@ public class ManifestTextInputFormat extends KeyValueTextInputFormat {
 
     private List<FileStatus> expandPath(Path globPath, JobConf conf) throws IOException {
         FileSystem fs = globPath.getFileSystem(conf);
-        FileStatus[] matches = fs.globStatus(globPath);
+
+        int attempts = 0;
+        boolean success = false;
+        FileStatus[] matches = null;
+        while (!success && attempts < RETRY_LIMIT) {
+            attempts += 1;
+            try {
+                matches = fs.globStatus(globPath);
+                success = true;
+            } catch (Exception exc) {
+                LOG.info("Exception while calling globStatus, retrying...", exc);
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException("This should never happen", e);
+                }
+            }
+        }
+
+        if (!success) {
+            throw new RuntimeException("Unable to fetch glob status '" + globPath.toUri() + "' after " + RETRY_LIMIT + " attempts");
+        }
 
         List<FileStatus> paths = new ArrayList<FileStatus>();
 
@@ -73,5 +106,4 @@ public class ManifestTextInputFormat extends KeyValueTextInputFormat {
 
         return paths;
     }
-
 }


### PR DESCRIPTION
Since we know each line is a file and not a potential directory that needs to be expanded then we do not need to attempt to expand the path.  However, we still need to check if the file is alive as dead files downstream will cause MR jobs to fail with HadoopJobError exceptions.